### PR TITLE
Fix deprecated syntax, bump to Ansible 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,15 @@
 ---
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ome-ansible-molecule-dependencies
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Upgrades all packages installed with the distribution's package manager
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency: []
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: upgrade-distpackages
+
+docker:
+  containers:
+  - name: upgrade-distpackages
+    image: centos
+    image_version: 7
+
+# In theory there is a very small chance of a race condition if new
+# updates become available during the test. If this happens re-run.
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-upgrade-distpackages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
     state: latest
     update_cache: yes
   with_items: "{{ upgrade_distpackages }}"
+  # Ignore ansible-lint warning about "latest"
+  tags:
+  - skip_ansible_lint
 
 - name: system | current running kernel
   command: uname -r
@@ -21,6 +24,9 @@
   register: latest_kernel_version
   check_mode: no
   changed_when: False
+  # Ignore ansible-lint warning about using rpm (this is just a query)
+  tags:
+  - skip_ansible_lint
 
 - name: system | check if reboot needed
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,14 @@
 - name: system | current running kernel
   command: uname -r
   register: running_kernel_version
-  always_run: True
+  check_mode: no
   changed_when: False
 
 # http://serverfault.com/a/601432
 - name: system | latest installed kernel
   shell: rpm -q kernel --qf '%{BUILDTIME} %{VERSION}-%{RELEASE}.%{ARCH}\n' | tail -n 1 | cut -f 2 -d ' '
   register: latest_kernel_version
-  always_run: True
+  check_mode: no
   changed_when: False
 
 - name: system | check if reboot needed

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - ansible-role-upgrade-distpackages

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,9 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_check_upgrade(Command):
+    # If upgrades are available this should fail
+    Command.check_output('yum check-upgrade')


### PR DESCRIPTION
Min is 2.2, ~~but I thought I'd bump to 2.3 since that's what we'll be testing~~