### PR TITLE
upgrade_distpackages_excludes to exclude packages during upgrade * (IDR-0.4.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Role Variables
 Optional variables:
 
 - `upgrade_distpackages`: List of packages to upgrade (default: all)
+- `upgrade_distpackages_excludes`: List of package specifications to exclude from upgrade
 - `upgrade_distpackages_reboot_kernel`: Automatically reboot if a new kernel is installed (default `False`)
 - `upgrade_distpackages_reboot_timeout`: Maximum time to wait for a reboot (default `600` seconds)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # List of packages to upgrade
 upgrade_distpackages: "*"
 
+# List of package specifications to exclude from upgrade
+upgrade_distpackages_excludes: []
+
 # Automatically reboot if running kernel is different from the latest installed?
 upgrade_distpackages_reboot_kernel: False
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   become: yes
   yum:
     name: "{{ item }}"
+    exclude: "{{ upgrade_distpackages_excludes | join(',') }}"
     state: latest
     update_cache: yes
   with_items: "{{ upgrade_distpackages }}"


### PR DESCRIPTION
This provides an easy way to upgrade all packages with the exception of a few

Tag: `1.1.0`